### PR TITLE
Add email functionality for meeting summaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,9 @@
-GEMINI_API_KEY=your_key_here
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+GEMINI_API_KEY=your_gemini_api_key_here
+PORT=3001
+NODE_ENV=development
+
+# Resend Email Configuration
+RESEND_API_KEY=your_resend_api_key_here
+SENDER_EMAIL=advisor@yourdomain.com
+SENDER_NAME=Fabric Client Management

--- a/server/config/constants.ts
+++ b/server/config/constants.ts
@@ -97,6 +97,25 @@ export const ERROR_MESSAGES = {
 } as const;
 
 /**
+ * Email Configuration
+ * Settings for Resend email service
+ */
+export const EMAIL_CONFIG = {
+  // Email sender details (from environment variables)
+  SENDER_EMAIL: process.env.SENDER_EMAIL || 'onboarding@resend.dev',
+  SENDER_NAME: process.env.SENDER_NAME || 'Fabric Client Management',
+
+  // Rate limiting (emails per minute per user)
+  RATE_LIMIT: {
+    MAX_EMAILS_PER_MINUTE: 10,
+  },
+
+  // Email preferences
+  DEFAULT_INCLUDE_TRANSCRIPTION: false,
+  DEFAULT_INCLUDE_REPORT: false,
+} as const;
+
+/**
  * API Endpoints
  * Base paths for different API routes
  */

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,7 +11,8 @@
         "@google/genai": "^1.34.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
-        "express": "^4.21.0"
+        "express": "^4.21.0",
+        "resend": "^6.6.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -589,6 +590,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1161,6 +1168,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
@@ -1279,6 +1292,12 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -1988,6 +2007,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2020,6 +2045,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.6.0.tgz",
+      "integrity": "sha512-d1WoOqSxj5x76JtQMrieNAG1kZkh4NU4f+Je1yq4++JsDpLddhEwnJlNfvkCzvUuZy9ZquWmMMAm2mENd2JvRw==",
+      "license": "MIT",
+      "dependencies": {
+        "svix": "1.76.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2331,6 +2382,35 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/svix": {
+      "version": "1.76.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.76.1.tgz",
+      "integrity": "sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "@types/node": "^22.7.5",
+        "es6-promise": "^4.2.8",
+        "fast-sha256": "^1.3.0",
+        "url-parse": "^1.5.10",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/@types/node": {
+      "version": "22.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/svix/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2406,6 +2486,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -2413,6 +2503,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,8 @@
     "@google/genai": "^1.34.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
-    "express": "^4.21.0"
+    "express": "^4.21.0",
+    "resend": "^6.6.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/server/services/database.ts
+++ b/server/services/database.ts
@@ -285,6 +285,44 @@ export async function getAllMeetingNotes(): Promise<Record<string, MeetingNote[]
 }
 
 /**
+ * Get a specific meeting note by client ID and meeting ID
+ * @param clientId - The client's ID
+ * @param meetingId - The meeting ID
+ * @returns The meeting note or null if not found
+ */
+export async function getMeetingNote(clientId: string, meetingId: string): Promise<MeetingNote | null> {
+  const notes = await getMeetingNotes(clientId);
+  return notes.find(n => n.id === meetingId) || null;
+}
+
+/**
+ * Get discovery report for a meeting if it exists
+ * @param clientId - The client's ID
+ * @param meetingId - The meeting ID
+ * @returns The discovery report object or null if not found
+ */
+export async function getDiscoveryReport(clientId: string, meetingId: string): Promise<any | null> {
+  const notes = await getMeetingNotes(clientId);
+  const note = notes.find(n => n.id === meetingId);
+
+  if (!note) {
+    return null;
+  }
+
+  const clientFolder = getClientFolderName(clientId);
+  const meetingFolderName = createMeetingFolderName(note.date, note.type);
+  const reportPath = path.join(DATA_FOLDER, clientFolder, meetingFolderName, 'reports', 'discovery-report.json');
+
+  try {
+    const reportContent = await fs.readFile(reportPath, 'utf-8');
+    return JSON.parse(reportContent);
+  } catch {
+    // Report doesn't exist or is not in JSON format
+    return null;
+  }
+}
+
+/**
  * Delete a specific meeting note
  * @param clientId - The client's ID
  * @param meetingId - The meeting note ID to delete

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -1,0 +1,223 @@
+import { Resend } from 'resend';
+import {
+  generateMeetingSummaryEmail,
+  generateMeetingSummaryPlainText,
+  generateDiscoveryReportEmail,
+  generateDiscoveryReportPlainText,
+} from './emailTemplates.js';
+
+// Initialize Resend client
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+// Email configuration from environment variables
+const SENDER_EMAIL = process.env.SENDER_EMAIL || 'onboarding@resend.dev';
+const SENDER_NAME = process.env.SENDER_NAME || 'Fabric Client Management';
+
+/**
+ * Email sending options
+ */
+interface SendMeetingSummaryEmailOptions {
+  recipientEmail: string;
+  recipientName: string;
+  clientName: string;
+  meetingType: string;
+  meetingDate: string;
+  advisorName: string;
+  summary: string;
+  transcription?: string;
+  includeTranscription?: boolean;
+}
+
+interface SendDiscoveryReportEmailOptions {
+  recipientEmail: string;
+  recipientName: string;
+  clientName: string;
+  meetingDate: string;
+  advisorName: string;
+  report: {
+    riskTolerance: string;
+    factFind: string;
+    capacityForLoss: string;
+    financialObjectives: string;
+  };
+}
+
+/**
+ * Email sending result
+ */
+export interface EmailResult {
+  success: boolean;
+  emailId?: string;
+  error?: string;
+}
+
+/**
+ * Send meeting summary email to client
+ */
+export async function sendMeetingSummaryEmail(
+  options: SendMeetingSummaryEmailOptions
+): Promise<EmailResult> {
+  try {
+    const {
+      recipientEmail,
+      recipientName,
+      clientName,
+      meetingType,
+      meetingDate,
+      advisorName,
+      summary,
+      transcription,
+      includeTranscription = false,
+    } = options;
+
+    // Validate email address
+    if (!recipientEmail || !recipientEmail.includes('@')) {
+      return {
+        success: false,
+        error: 'Invalid recipient email address',
+      };
+    }
+
+    // Generate email content
+    const html = generateMeetingSummaryEmail({
+      clientName,
+      meetingType,
+      meetingDate,
+      advisorName,
+      summary,
+      transcription,
+      includeTranscription,
+    });
+
+    const text = generateMeetingSummaryPlainText({
+      clientName,
+      meetingType,
+      meetingDate,
+      advisorName,
+      summary,
+      transcription,
+      includeTranscription,
+    });
+
+    const subject = `Meeting Summary - ${meetingType} - ${new Date(meetingDate).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })}`;
+
+    // Send email via Resend
+    const result = await resend.emails.send({
+      from: `${SENDER_NAME} <${SENDER_EMAIL}>`,
+      to: [recipientEmail],
+      subject,
+      html,
+      text,
+    });
+
+    return {
+      success: true,
+      emailId: result.data?.id,
+    };
+  } catch (error: any) {
+    console.error('Failed to send meeting summary email:', error);
+    return {
+      success: false,
+      error: error.message || 'Failed to send email',
+    };
+  }
+}
+
+/**
+ * Send discovery report email to client
+ */
+export async function sendDiscoveryReportEmail(
+  options: SendDiscoveryReportEmailOptions
+): Promise<EmailResult> {
+  try {
+    const {
+      recipientEmail,
+      recipientName,
+      clientName,
+      meetingDate,
+      advisorName,
+      report,
+    } = options;
+
+    // Validate email address
+    if (!recipientEmail || !recipientEmail.includes('@')) {
+      return {
+        success: false,
+        error: 'Invalid recipient email address',
+      };
+    }
+
+    // Generate email content
+    const html = generateDiscoveryReportEmail({
+      clientName,
+      meetingDate,
+      advisorName,
+      report,
+    });
+
+    const text = generateDiscoveryReportPlainText({
+      clientName,
+      meetingDate,
+      advisorName,
+      report,
+    });
+
+    const subject = `Discovery Report - ${clientName} - ${new Date(meetingDate).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })}`;
+
+    // Send email via Resend
+    const result = await resend.emails.send({
+      from: `${SENDER_NAME} <${SENDER_EMAIL}>`,
+      to: [recipientEmail],
+      subject,
+      html,
+      text,
+    });
+
+    return {
+      success: true,
+      emailId: result.data?.id,
+    };
+  } catch (error: any) {
+    console.error('Failed to send discovery report email:', error);
+    return {
+      success: false,
+      error: error.message || 'Failed to send email',
+    };
+  }
+}
+
+/**
+ * Validate Resend API key configuration
+ */
+export function validateEmailConfiguration(): { valid: boolean; error?: string } {
+  if (!process.env.RESEND_API_KEY) {
+    return {
+      valid: false,
+      error: 'RESEND_API_KEY environment variable is not set',
+    };
+  }
+
+  if (!process.env.RESEND_API_KEY.startsWith('re_')) {
+    return {
+      valid: false,
+      error: 'RESEND_API_KEY appears to be invalid (should start with "re_")',
+    };
+  }
+
+  if (!SENDER_EMAIL || !SENDER_EMAIL.includes('@')) {
+    return {
+      valid: false,
+      error: 'SENDER_EMAIL environment variable is not set or invalid',
+    };
+  }
+
+  return { valid: true };
+}

--- a/server/services/emailTemplates.ts
+++ b/server/services/emailTemplates.ts
@@ -1,0 +1,312 @@
+/**
+ * Email templates for meeting summaries and discovery reports
+ */
+
+interface MeetingSummaryEmailParams {
+  clientName: string;
+  meetingType: string;
+  meetingDate: string;
+  advisorName: string;
+  summary: string;
+  transcription?: string;
+  includeTranscription: boolean;
+}
+
+interface DiscoveryReportEmailParams {
+  clientName: string;
+  meetingDate: string;
+  advisorName: string;
+  report: {
+    riskTolerance: string;
+    factFind: string;
+    capacityForLoss: string;
+    financialObjectives: string;
+  };
+}
+
+/**
+ * Generate HTML email template for meeting summary
+ */
+export function generateMeetingSummaryEmail(params: MeetingSummaryEmailParams): string {
+  const {
+    clientName,
+    meetingType,
+    meetingDate,
+    advisorName,
+    summary,
+    transcription,
+    includeTranscription,
+  } = params;
+
+  const formattedDate = new Date(meetingDate).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  // Convert summary paragraphs to HTML
+  const summaryHtml = summary
+    .split('\n\n')
+    .map((paragraph) => `<p style="margin: 0 0 16px 0; line-height: 1.6;">${paragraph}</p>`)
+    .join('');
+
+  const transcriptionSection = includeTranscription && transcription
+    ? `
+    <div style="margin-top: 32px; padding: 20px; background-color: #f8f9fa; border-radius: 8px;">
+      <h2 style="margin: 0 0 16px 0; color: #1a1a1a; font-size: 18px; font-weight: 600;">Full Transcription</h2>
+      <div style="color: #4a5568; font-size: 14px; line-height: 1.8; white-space: pre-wrap;">${transcription}</div>
+    </div>
+    `
+    : '';
+
+  return `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Meeting Summary - ${meetingType}</title>
+    </head>
+    <body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f5f5f5;">
+      <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff;">
+        <!-- Header -->
+        <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 40px 32px; text-align: center;">
+          <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px;">Fabric</h1>
+          <p style="margin: 8px 0 0 0; color: #e9d5ff; font-size: 14px;">Client Management Platform</p>
+        </div>
+
+        <!-- Content -->
+        <div style="padding: 32px;">
+          <!-- Meeting Info -->
+          <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 2px solid #e5e7eb;">
+            <h2 style="margin: 0 0 16px 0; color: #1a1a1a; font-size: 22px; font-weight: 600;">Meeting Summary</h2>
+            <div style="display: table; width: 100%;">
+              <div style="display: table-row;">
+                <div style="display: table-cell; padding: 8px 0; color: #6b7280; font-size: 14px; font-weight: 500; width: 120px;">Client:</div>
+                <div style="display: table-cell; padding: 8px 0; color: #1a1a1a; font-size: 14px;">${clientName}</div>
+              </div>
+              <div style="display: table-row;">
+                <div style="display: table-cell; padding: 8px 0; color: #6b7280; font-size: 14px; font-weight: 500; width: 120px;">Meeting Type:</div>
+                <div style="display: table-cell; padding: 8px 0; color: #1a1a1a; font-size: 14px;">${meetingType}</div>
+              </div>
+              <div style="display: table-row;">
+                <div style="display: table-cell; padding: 8px 0; color: #6b7280; font-size: 14px; font-weight: 500; width: 120px;">Date:</div>
+                <div style="display: table-cell; padding: 8px 0; color: #1a1a1a; font-size: 14px;">${formattedDate}</div>
+              </div>
+              <div style="display: table-row;">
+                <div style="display: table-cell; padding: 8px 0; color: #6b7280; font-size: 14px; font-weight: 500; width: 120px;">Advisor:</div>
+                <div style="display: table-cell; padding: 8px 0; color: #1a1a1a; font-size: 14px;">${advisorName}</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Summary -->
+          <div style="margin-bottom: 24px;">
+            <h3 style="margin: 0 0 16px 0; color: #1a1a1a; font-size: 18px; font-weight: 600;">Summary</h3>
+            <div style="color: #374151;">
+              ${summaryHtml}
+            </div>
+          </div>
+
+          ${transcriptionSection}
+        </div>
+
+        <!-- Footer -->
+        <div style="padding: 24px 32px; background-color: #f9fafb; border-top: 1px solid #e5e7eb;">
+          <p style="margin: 0 0 8px 0; color: #6b7280; font-size: 12px; line-height: 1.5;">
+            <strong>Confidential:</strong> This email contains confidential financial information. Please do not forward or share without authorization.
+          </p>
+          <p style="margin: 0; color: #9ca3af; font-size: 12px;">
+            Generated by Fabric Client Management Platform
+          </p>
+        </div>
+      </div>
+    </body>
+    </html>
+  `;
+}
+
+/**
+ * Generate HTML email template for discovery report
+ */
+export function generateDiscoveryReportEmail(params: DiscoveryReportEmailParams): string {
+  const { clientName, meetingDate, advisorName, report } = params;
+
+  const formattedDate = new Date(meetingDate).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  return `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Discovery Report - ${clientName}</title>
+    </head>
+    <body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f5f5f5;">
+      <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff;">
+        <!-- Header -->
+        <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 40px 32px; text-align: center;">
+          <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px;">Fabric</h1>
+          <p style="margin: 8px 0 0 0; color: #e9d5ff; font-size: 14px;">Client Management Platform</p>
+        </div>
+
+        <!-- Content -->
+        <div style="padding: 32px;">
+          <!-- Report Info -->
+          <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 2px solid #e5e7eb;">
+            <h2 style="margin: 0 0 16px 0; color: #1a1a1a; font-size: 22px; font-weight: 600;">Discovery Report</h2>
+            <div style="display: table; width: 100%;">
+              <div style="display: table-row;">
+                <div style="display: table-cell; padding: 8px 0; color: #6b7280; font-size: 14px; font-weight: 500; width: 120px;">Client:</div>
+                <div style="display: table-cell; padding: 8px 0; color: #1a1a1a; font-size: 14px;">${clientName}</div>
+              </div>
+              <div style="display: table-row;">
+                <div style="display: table-cell; padding: 8px 0; color: #6b7280; font-size: 14px; font-weight: 500; width: 120px;">Date:</div>
+                <div style="display: table-cell; padding: 8px 0; color: #1a1a1a; font-size: 14px;">${formattedDate}</div>
+              </div>
+              <div style="display: table-row;">
+                <div style="display: table-cell; padding: 8px 0; color: #6b7280; font-size: 14px; font-weight: 500; width: 120px;">Advisor:</div>
+                <div style="display: table-cell; padding: 8px 0; color: #1a1a1a; font-size: 14px;">${advisorName}</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Report Sections -->
+          <div style="margin-bottom: 32px;">
+            <h3 style="margin: 0 0 12px 0; color: #667eea; font-size: 18px; font-weight: 600;">Risk Tolerance Assessment</h3>
+            <p style="margin: 0; color: #374151; font-size: 14px; line-height: 1.6;">${report.riskTolerance}</p>
+          </div>
+
+          <div style="margin-bottom: 32px;">
+            <h3 style="margin: 0 0 12px 0; color: #667eea; font-size: 18px; font-weight: 600;">Fact Find Summary</h3>
+            <p style="margin: 0; color: #374151; font-size: 14px; line-height: 1.6;">${report.factFind}</p>
+          </div>
+
+          <div style="margin-bottom: 32px;">
+            <h3 style="margin: 0 0 12px 0; color: #667eea; font-size: 18px; font-weight: 600;">Capacity for Loss Analysis</h3>
+            <p style="margin: 0; color: #374151; font-size: 14px; line-height: 1.6;">${report.capacityForLoss}</p>
+          </div>
+
+          <div style="margin-bottom: 32px;">
+            <h3 style="margin: 0 0 12px 0; color: #667eea; font-size: 18px; font-weight: 600;">Financial Objectives Overview</h3>
+            <p style="margin: 0; color: #374151; font-size: 14px; line-height: 1.6;">${report.financialObjectives}</p>
+          </div>
+        </div>
+
+        <!-- Footer -->
+        <div style="padding: 24px 32px; background-color: #f9fafb; border-top: 1px solid #e5e7eb;">
+          <p style="margin: 0 0 8px 0; color: #6b7280; font-size: 12px; line-height: 1.5;">
+            <strong>Confidential:</strong> This discovery report contains highly confidential financial information. Please do not forward or share without authorization.
+          </p>
+          <p style="margin: 0 0 8px 0; color: #6b7280; font-size: 12px; line-height: 1.5;">
+            <strong>Disclaimer:</strong> This report is for informational purposes only and does not constitute financial advice. Please consult with your financial advisor before making any investment decisions.
+          </p>
+          <p style="margin: 0; color: #9ca3af; font-size: 12px;">
+            Generated by Fabric Client Management Platform
+          </p>
+        </div>
+      </div>
+    </body>
+    </html>
+  `;
+}
+
+/**
+ * Generate plain text version of meeting summary email
+ */
+export function generateMeetingSummaryPlainText(params: MeetingSummaryEmailParams): string {
+  const {
+    clientName,
+    meetingType,
+    meetingDate,
+    advisorName,
+    summary,
+    transcription,
+    includeTranscription,
+  } = params;
+
+  const formattedDate = new Date(meetingDate).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  let plainText = `
+MEETING SUMMARY
+===============
+
+Client: ${clientName}
+Meeting Type: ${meetingType}
+Date: ${formattedDate}
+Advisor: ${advisorName}
+
+SUMMARY
+-------
+${summary}
+`;
+
+  if (includeTranscription && transcription) {
+    plainText += `
+
+FULL TRANSCRIPTION
+------------------
+${transcription}
+`;
+  }
+
+  plainText += `
+
+---
+Confidential: This email contains confidential financial information.
+Generated by Fabric Client Management Platform
+`;
+
+  return plainText.trim();
+}
+
+/**
+ * Generate plain text version of discovery report email
+ */
+export function generateDiscoveryReportPlainText(params: DiscoveryReportEmailParams): string {
+  const { clientName, meetingDate, advisorName, report } = params;
+
+  const formattedDate = new Date(meetingDate).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  return `
+DISCOVERY REPORT
+===============
+
+Client: ${clientName}
+Date: ${formattedDate}
+Advisor: ${advisorName}
+
+RISK TOLERANCE ASSESSMENT
+-------------------------
+${report.riskTolerance}
+
+FACT FIND SUMMARY
+-----------------
+${report.factFind}
+
+CAPACITY FOR LOSS ANALYSIS
+--------------------------
+${report.capacityForLoss}
+
+FINANCIAL OBJECTIVES OVERVIEW
+------------------------------
+${report.financialObjectives}
+
+---
+Confidential: This discovery report contains highly confidential financial information.
+Disclaimer: This report is for informational purposes only and does not constitute financial advice.
+Generated by Fabric Client Management Platform
+`.trim();
+}

--- a/src/components/dashboard/MainPanel.tsx
+++ b/src/components/dashboard/MainPanel.tsx
@@ -20,6 +20,7 @@ interface MainPanelProps {
   onSkipReport?: () => void;
   meetingSummary: string;
   clientMeetingNotes: Record<string, MeetingNote[]>;
+  meetingId?: string;
 }
 
 export function MainPanel({
@@ -35,7 +36,8 @@ export function MainPanel({
   onGenerateDiscoveryReport,
   onSkipReport,
   meetingSummary,
-  clientMeetingNotes
+  clientMeetingNotes,
+  meetingId
 }: MainPanelProps) {
   const isMeetingActive = recordingState !== 'idle';
 
@@ -57,7 +59,15 @@ export function MainPanel({
 
       <div className="flex-1 overflow-auto">
         {activeView === 'documentation' && <DocumentationView clientId={client.id} />}
-        {activeView === 'meeting-notes' && <MeetingNotesView clientId={client.id} meetingNotes={clientMeetingNotes[client.id] || []} />}
+        {activeView === 'meeting-notes' && (
+          <MeetingNotesView
+            clientId={client.id}
+            meetingNotes={clientMeetingNotes[client.id] || []}
+            clientName={client.name}
+            clientEmail={client.email}
+            advisorName={client.advisor}
+          />
+        )}
         {activeView === 'meeting-prep' && <MeetingPrepView clientId={client.id} />}
         {activeView === 'start-meeting' && !isMeetingActive && (
           <StartMeetingView
@@ -77,6 +87,11 @@ export function MainPanel({
               onGenerateDiscoveryReport={onGenerateDiscoveryReport}
               onSkipReport={onSkipReport}
               meetingSummary={meetingSummary}
+              clientId={client.id}
+              clientName={client.name}
+              clientEmail={client.email}
+              advisorName={client.advisor}
+              meetingId={meetingId}
             />
           </div>
         )}

--- a/src/components/dashboard/MeetingNotesView.tsx
+++ b/src/components/dashboard/MeetingNotesView.tsx
@@ -1,4 +1,4 @@
-import { Calendar, Play, TrendingUp, FileText, CheckSquare } from 'lucide-react';
+import { Calendar, Play, TrendingUp, FileText, CheckSquare, Mail, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { MeetingNote, overallTrends } from '@/data/mockData';
 import {
@@ -8,16 +8,78 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
 import { ActionsTab } from './ActionsTab';
+import { sendMeetingEmail } from '@/services/api';
+import { toast } from 'sonner';
+import { useState } from 'react';
 
 interface MeetingNotesViewProps {
   clientId: string;
   meetingNotes: MeetingNote[];
+  clientName?: string;
+  clientEmail?: string;
+  advisorName?: string;
 }
 
-export function MeetingNotesView({ clientId, meetingNotes }: MeetingNotesViewProps) {
+export function MeetingNotesView({ clientId, meetingNotes, clientName, clientEmail, advisorName }: MeetingNotesViewProps) {
   const notes = meetingNotes;
   const trends = overallTrends[clientId] || [];
+  const [sendingEmailFor, setSendingEmailFor] = useState<string | null>(null);
+  const [emailDialogOpen, setEmailDialogOpen] = useState(false);
+  const [selectedMeetingId, setSelectedMeetingId] = useState<string>('');
+  const [recipientEmail, setRecipientEmail] = useState('s.edscer@gmail.com');
+  const [includeTranscription, setIncludeTranscription] = useState(false);
+
+  const handleOpenEmailDialog = (meetingId: string, event: React.MouseEvent) => {
+    event.stopPropagation(); // Prevent accordion from toggling
+    setSelectedMeetingId(meetingId);
+    setEmailDialogOpen(true);
+  };
+
+  const handleSendEmail = async () => {
+    if (!clientName || !advisorName) {
+      toast.error('Missing client information to send email');
+      return;
+    }
+
+    if (!recipientEmail || !recipientEmail.includes('@')) {
+      toast.error('Please enter a valid email address');
+      return;
+    }
+
+    setSendingEmailFor(selectedMeetingId);
+    setEmailDialogOpen(false);
+
+    try {
+      await sendMeetingEmail({
+        clientId,
+        meetingId: selectedMeetingId,
+        recipientEmail,
+        clientName,
+        advisorName,
+        includeTranscription,
+      });
+      toast.success(`Meeting summary sent to ${recipientEmail}`);
+      // Reset to default
+      setRecipientEmail('s.edscer@gmail.com');
+      setIncludeTranscription(false);
+    } catch (error: any) {
+      toast.error(error.message || 'Failed to send email');
+    } finally {
+      setSendingEmailFor(null);
+    }
+  };
 
   return (
     <div className="px-12 pt-12 pb-12 max-w-[800px]">
@@ -36,18 +98,36 @@ export function MeetingNotesView({ clientId, meetingNotes }: MeetingNotesViewPro
                 className="border border-border rounded-lg bg-card overflow-hidden"
               >
                 <AccordionTrigger className="px-4 py-3 hover:no-underline hover:bg-secondary transition-fast">
-                  <div className="flex items-center gap-3 text-left">
-                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                      <Calendar className="w-4 h-4" strokeWidth={1.5} />
-                      {new Date(note.date).toLocaleDateString('en-US', {
-                        month: 'short',
-                        day: 'numeric',
-                        year: 'numeric',
-                      })}
+                  <div className="flex items-center justify-between w-full gap-3">
+                    <div className="flex items-center gap-3 text-left">
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <Calendar className="w-4 h-4" strokeWidth={1.5} />
+                        {new Date(note.date).toLocaleDateString('en-US', {
+                          month: 'short',
+                          day: 'numeric',
+                          year: 'numeric',
+                        })}
+                      </div>
+                      <span className="text-xs text-secondary-foreground bg-secondary px-2 py-0.5 rounded">
+                        {note.type}
+                      </span>
                     </div>
-                    <span className="text-xs text-secondary-foreground bg-secondary px-2 py-0.5 rounded">
-                      {note.type}
-                    </span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 px-3 gap-2"
+                      onClick={(e) => handleOpenEmailDialog(note.id, e)}
+                      disabled={sendingEmailFor === note.id}
+                    >
+                      {sendingEmailFor === note.id ? (
+                        <Loader2 className="w-4 h-4 animate-spin" strokeWidth={1.5} />
+                      ) : (
+                        <Mail className="w-4 h-4" strokeWidth={1.5} />
+                      )}
+                      <span className="text-xs">
+                        {sendingEmailFor === note.id ? 'Sending...' : 'Email'}
+                      </span>
+                    </Button>
                   </div>
                 </AccordionTrigger>
                 <AccordionContent className="px-4 pb-4">
@@ -145,6 +225,54 @@ export function MeetingNotesView({ clientId, meetingNotes }: MeetingNotesViewPro
           </ul>
         )}
       </section>
+
+      {/* Email Dialog */}
+      <Dialog open={emailDialogOpen} onOpenChange={setEmailDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Email Meeting Summary</DialogTitle>
+            <DialogDescription>
+              Send the meeting summary to a specified email address.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="email-meeting-notes">Recipient Email</Label>
+              <Input
+                id="email-meeting-notes"
+                type="email"
+                placeholder="email@example.com"
+                value={recipientEmail}
+                onChange={(e) => setRecipientEmail(e.target.value)}
+              />
+            </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="includeTranscription-meeting-notes"
+                checked={includeTranscription}
+                onCheckedChange={(checked) => setIncludeTranscription(checked as boolean)}
+              />
+              <Label
+                htmlFor="includeTranscription-meeting-notes"
+                className="text-sm font-normal cursor-pointer"
+              >
+                Include full transcription
+              </Label>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setEmailDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleSendEmail}>
+              Send Email
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -219,6 +219,7 @@ const Index = () => {
           onSkipReport={handleSkipReport}
           meetingSummary={meetingSummary}
           clientMeetingNotes={clientMeetingNotes}
+          meetingId={meetingId}
         />
       </div>
     </div>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -186,6 +186,45 @@ export async function generateDiscoveryReport(
 }
 
 /**
+ * Send meeting summary email to client
+ */
+export interface SendEmailRequest {
+  clientId: string;
+  meetingId: string;
+  recipientEmail: string;
+  clientName: string;
+  advisorName: string;
+  includeTranscription?: boolean;
+  includeReport?: boolean;
+}
+
+export interface SendEmailResponse {
+  success: boolean;
+  message?: string;
+  emailId?: string;
+  error?: string;
+}
+
+export async function sendMeetingEmail(
+  request: SendEmailRequest
+): Promise<SendEmailResponse> {
+  const { clientId, meetingId, ...body } = request;
+
+  const response = await fetch(`${API_BASE}/api/meetings/${clientId}/${meetingId}/send-email`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || `API error: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/**
  * @deprecated Use processMeeting instead
  */
 export async function summarizeMeeting(transcription: string): Promise<string> {


### PR DESCRIPTION
## Summary

Implement comprehensive email functionality allowing financial advisors to send meeting summaries and discovery reports to clients via email using Resend API.

### Key Features
- **Email Dialog**: Interactive dialog to specify recipient email (default: s.edscer@gmail.com)
- **Professional Templates**: HTML email templates with Fabric branding
- **Flexible Options**: Option to include full transcription in emails
- **Two Integration Points**:
  - RecordingOverlay: Email summary immediately after generation
  - MeetingNotesView: Email any saved meeting summary
- **Resend Integration**: Uses Resend SDK for reliable email delivery (free tier: 3,000 emails/month)

### Backend Changes
- Installed `resend` npm package
- Created email service (`server/services/email.ts`) with Resend SDK integration
- Created professional HTML email templates (`server/services/emailTemplates.ts`)
- Added email configuration to constants
- Added new API endpoint: `POST /api/meetings/:clientId/:meetingId/send-email`
- Extended database service with `getMeetingNote()` and `getDiscoveryReport()` functions

### Frontend Changes
- Added email dialog component with customizable recipient field
- Added "Email Summary" button to RecordingOverlay component
- Added "Email" button to each meeting in MeetingNotesView
- Implemented loading states and toast notifications
- Added checkbox option to include full transcription

### Email Templates
- Meeting summary emails with professional formatting
- Discovery report emails (when available)
- Plain text fallback for email clients
- Confidential disclaimer footer
- Responsive design for mobile and desktop

### Configuration
Requires environment variables in `.env`:
```bash
RESEND_API_KEY=your_resend_api_key_here
SENDER_EMAIL=onboarding@resend.dev
SENDER_NAME=Fabric Client Management
```

## Test Plan

### Setup
- [ ] Sign up for Resend account at https://resend.com (free tier)
- [ ] Get API key from Resend dashboard
- [ ] Add `RESEND_API_KEY` to `.env` file
- [ ] Restart server with `npm run dev:all`

### Testing Email from RecordingOverlay
- [ ] Start a new meeting in the app
- [ ] Stop recording and wait for summary generation
- [ ] Click "Email Summary" button
- [ ] Verify dialog opens with email pre-filled to s.edscer@gmail.com
- [ ] Optionally change email address
- [ ] Check/uncheck "Include full transcription" option
- [ ] Click "Send Email"
- [ ] Verify toast notification shows "Meeting summary sent to [email]"
- [ ] Check recipient's inbox for professional email with meeting summary

### Testing Email from MeetingNotesView
- [ ] Navigate to "Meeting Notes" tab
- [ ] Click "Email" button on any saved meeting
- [ ] Verify dialog opens with email pre-filled to s.edscer@gmail.com
- [ ] Change email address if desired
- [ ] Toggle transcription option
- [ ] Click "Send Email"
- [ ] Verify success notification
- [ ] Check recipient's inbox for email

### Edge Cases
- [ ] Verify email validation (shows error for invalid email)
- [ ] Test with missing Resend API key (should show configuration error)
- [ ] Test loading state (button shows "Sending..." while email sends)
- [ ] Test error handling (simulate API failure)

### Email Content Verification
- [ ] Verify email has professional Fabric branding
- [ ] Check meeting metadata displays correctly (date, type, advisor)
- [ ] Confirm summary formatting is readable
- [ ] If transcription included, verify it appears in email
- [ ] Check confidential disclaimer appears in footer
- [ ] Test email renders well on mobile and desktop

## Notes
- Default recipient email is set to s.edscer@gmail.com but can be customized per send
- Email field resets to default after each successful send
- Using Resend's test domain (onboarding@resend.dev) for development
- For production, configure custom domain in Resend dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)